### PR TITLE
Apply diff comes from PyTFTPd-private

### DIFF
--- a/tftp_common.py
+++ b/tftp_common.py
@@ -3,7 +3,7 @@ from enum import Enum, unique
 import signal
 
 DEBUG = False
-INFO = True
+INFO = False
 
 
 @unique
@@ -198,8 +198,8 @@ class RQPacket(TFTPPacket):
                 block_size = int(packet[i + 1])
             elif packet[i].lower() == b'windowsize':
                 window_size = int(packet[i + 1])
-            elif packet[i] != b'':
-                bad_opts = True
+            # elif packet[i] != b'':
+            #     bad_opts = True
         return constructor(packet[0], TransferModes.get_mode(packet[1]), block_size, window_size, bad_opts)
 
 


### PR DESCRIPTION
We have a copied PyTFTPd at `/nfs/teams/verif/static/sys_validation/jenkins/fpga_regression/tools/PyTFTPd-private` at 2022-06-07 with Max Hsu's help. It has a little code change without versioning.

While it is used in System Validation regression flow, I forked origin PyTFTPd repository and apply the diff in order to maintain our use on GitHub.